### PR TITLE
Improve snapshot script error handling

### DIFF
--- a/grab_snapshot.sh
+++ b/grab_snapshot.sh
@@ -70,12 +70,15 @@ if (( current_hour >= START_HOUR && current_hour <= END_HOUR )); then
       echo "Error: failed to fetch embed page from $EMBED_URL (curl exit $curl_status)" >&2
       exit 1
     fi
-    STREAM_URL=$(echo "$embed_page" | grep -oP '"streamSrc":"\K[^"]+' || true)
+    # Extract the first HLS (.m3u8) URL from the embed page. The stream URL
+    # appears URL-escaped (e.g. "https:\/\/...") so we unescape any
+    # backslashes after matching.
+    STREAM_URL=$(echo "$embed_page" | grep -oP 'https:\\/\\/[^"\n]+?m3u8' | head -n 1 || true)
     if [[ -z "$STREAM_URL" ]]; then
       echo "Error: stream URL not found in embed page" >&2
       exit 1
     fi
-    printf -v STREAM_URL '%b' "$STREAM_URL"
+    STREAM_URL="${STREAM_URL//\\/}"
   fi
 
   echo "STREAM_URL=$STREAM_URL"

--- a/grab_snapshot.sh
+++ b/grab_snapshot.sh
@@ -25,6 +25,8 @@
 
 set -euo pipefail
 
+echo "Starting snapshot capture"
+
 # Base directory for snapshots relative to the repository root
 BASE_DIR="$(dirname "$0")/snapshots"
 
@@ -68,7 +70,11 @@ if (( current_hour >= START_HOUR && current_hour <= END_HOUR )); then
       echo "Error: failed to fetch embed page from $EMBED_URL (curl exit $curl_status)" >&2
       exit 1
     fi
-    STREAM_URL=$(echo "$embed_page" | grep -oP '"streamSrc":"\K[^"]+')
+    STREAM_URL=$(echo "$embed_page" | grep -oP '"streamSrc":"\K[^"]+' || true)
+    if [[ -z "$STREAM_URL" ]]; then
+      echo "Error: stream URL not found in embed page" >&2
+      exit 1
+    fi
     printf -v STREAM_URL '%b' "$STREAM_URL"
   fi
 


### PR DESCRIPTION
## Summary
- ensure grab_snapshot.sh always prints status messages
- fail with clear errors if the stream URL can't be fetched or if the snapshot isn't written
- allow optional STREAM_URL_OVERRIDE for testing and verify saved images

## Testing
- `bash -n grab_snapshot.sh`
- `STREAM_URL_OVERRIDE=https://raw.githubusercontent.com/mediaelement/mediaelement-files/master/big_buck_bunny.mp4 ./grab_snapshot.sh`
- `./grab_snapshot.sh` *(expected failure: Error: failed to fetch embed page ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bfa53b9c832fb383f93775caaa22